### PR TITLE
Resolve various bugs stemming from SVAN-INS.py and SVAN-DEL.py

### DIFF
--- a/SVAN-DEL.py
+++ b/SVAN-DEL.py
@@ -2212,7 +2212,7 @@ def nested_annot(retro_annot, reference, minMAPQ, minHitLen, fileName, outDir):
     
     ## Discard if no hit passes the filters
     if not PAF_cons.alignments:
-        return
+        return retro_annot
     
     ## Group alignments by insertion id
     consHitsTd = group_alignments(PAF_cons)

--- a/SVAN-INS.py
+++ b/SVAN-INS.py
@@ -2557,7 +2557,7 @@ def nested_annot(retro_annot, reference, minMAPQ, minHitLen, fileName, outDir):
     
     ## Discard if no hit passes the filters
     if not PAF_cons.alignments:
-        return
+        return retro_annot
     
     ## Group alignments by insertion id
     consHitsTd = group_alignments(PAF_cons)

--- a/SVAN-INS.py
+++ b/SVAN-INS.py
@@ -122,9 +122,9 @@ def annot_tandem_dup(VCF, PAFs_ref):
 
         ## Define insertion interval
         offset = 1000
-        iChr, pos = insId.split('_')[1].split(':')
-        iBeg = int(pos) - offset
-        iEnd = int(pos) + offset
+        iChr = variant.chrom
+        iBeg = variant.pos - offset
+        iEnd = variant.pos + offset
 
         ## Filter out hits outside insertion interval
         filteredHits = []
@@ -427,7 +427,8 @@ def annot_interspersed_dup(VCF, PAFs_ref):
         if chain.perc_query_covered() >= 75:
 
             ## Add duplication annotation to the variant info
-            tmp = {'ITYPE_N': 'DUP_INTERSPERSED'}
+            coords = ','.join([hit.tName + ':' + str(hit.tBeg) + '-' + str(hit.tEnd) + '_' + hit.strand for hit in chain.alignments])
+            tmp = {'ITYPE_N': 'DUP_INTERSPERSED', 'DUP_COORD': coords}
             variant.info.update(tmp)
 
             ## Add duplication call to the VCF
@@ -1569,7 +1570,7 @@ def filter_partnered_ipos(retro_annot):
             continue
 
         ## Collect coordinates for insertion interval 
-        tmp = insId.split('_')[1]
+        tmp = insId.rsplit('_', 1)[1]
         iChr, iPos = tmp.split(':')
         iBeg = int(iPos) - 1000
         iEnd = int(iPos) + 1000
@@ -1618,7 +1619,7 @@ def reclassify_5prime_partnered_ipos(retro_annot):
             continue
 
         ## Collect coordinates for insertion interval 
-        tmp = insId.split('_')[1]
+        tmp = insId.rsplit('_', 1)[1]
         iChr, iPos = tmp.split(':')
         iBeg = int(iPos) - 1000
         iEnd = int(iPos) + 1000
@@ -2289,7 +2290,7 @@ def templated_ins(retro_annot, chain):
     offset = 50000
     firstHit = chain.alignments[0]
     insIdRef, coord = firstHit.qName.split(':')
-    iRef = insIdRef.split('_')[1]
+    iRef = insIdRef.rsplit('_', 1)[1]
     iBeg = int(coord) - offset
     iEnd = int(coord) + offset
     
@@ -3144,7 +3145,7 @@ maxLen = 50000
 filtered_VCF = filter_VCF_len(VCF, maxLen)
 print('VCF: ', len(VCF.variants), len(filtered_VCF.variants))
 
-## 1. Load input files 
+## 1. Load input files 
 #######################
 print('1. Load input files')
 
@@ -3166,7 +3167,7 @@ print('1.d Annotated repeats')
 print('2. Annotate repetitive sequences at the insertion breakpoints')
 #annotate_repeats_bkp(filtered_VCF, repeatsBinDb)
 
-## 3. Align inserts to reference
+## 3. Align inserts to reference
 #################################
 print('3. Align inserts to reference')
 PAFs_ref = align_ins2ref(filtered_VCF, reference, tmpDir)


### PR DESCRIPTION
Hi @jemilianosf,

In response to your comments on the issues that I opened up, I've created a fork that contains several fixes to them.

Below, I'm attaching details as to how they resolve each issue:
- https://github.com/REPBIO-LAB/SVAN/issues/5: Line 2215 in `SVAN-DEL.py` now returns a valid dictionary which can be iterated over, rather than the `NoneType` object before.
- https://github.com/REPBIO-LAB/SVAN/issues/7: Line 430 in `SVAN-INS.py` now populates a string used as the `DUP_COORD` INFO tag in a manner similar to how other insertions with an `ITYPE_N` tag are populated.
- https://github.com/REPBIO-LAB/SVAN/issues/8: Line 125 in `SVAN-INS.py` now pulls the chromosome directly from the record itself, rather than its ID. The use of `rsplit()` instead of `split()` also ensures we now split on the final `_` character to get the coordination information, which is necessary in the event that the variant ID has other `_` characters within it. 

Please let me know if you have any further questions about these changes. Thanks in advance, and look forward to seeing the development of this tool.

Karan